### PR TITLE
(bug) stop description being removed when updating post title

### DIFF
--- a/src/MoneroBot.Daemon/Features/SynchronizePostDonationComments.cs
+++ b/src/MoneroBot.Daemon/Features/SynchronizePostDonationComments.cs
@@ -331,7 +331,7 @@ public class SynchronizePostDonationCommentsHandler : ISynchronizePostDonationCo
         {
             try
             {
-                await this.fider.EditPostAsync((int)command.PostNumber, title: expected, token: token);
+                await this.fider.EditPostAsync((int)command.PostNumber, title: expected, description: post.Description, token: token);
                 this.logger.LogInformation("Successfully updated the title of post #{PostNumber} from '{PreviousTitle}' to '{NewTitle}' so as to match the new total donation amount.", command.PostNumber, current, expected);
             }
             catch (HttpRequestException error)

--- a/src/MoneroBot.Fider/FiderApiClient.cs
+++ b/src/MoneroBot.Fider/FiderApiClient.cs
@@ -85,11 +85,11 @@ public class FiderApiClient : IFiderApiClient
         return result;
     }
 
-    public async Task EditPostAsync(int postNumber, string title, string? description = null, CancellationToken token = default) 
+    public async Task EditPostAsync(int postNumber, string title, string? description, CancellationToken token = default) 
     {
         var data = new StringContent(
             JsonSerializer.Serialize(
-                description is null ? new { title } as object : new { title, description }),
+                new { title, description }),
                 Encoding.UTF8,
                 MediaTypeNames.Application.Json);
         var response = await this.http.PutAsync(Endpoints.EditPost(postNumber), data);

--- a/src/MoneroBot.Fider/IFiderApiClient.cs
+++ b/src/MoneroBot.Fider/IFiderApiClient.cs
@@ -18,5 +18,5 @@ public interface IFiderApiClient
 
     public Task DeleteCommentAsync(int postNumber, int commentId, CancellationToken token = default);
 
-    public Task EditPostAsync(int postNumber, string title, string? description = null, CancellationToken token = default);
+    public Task EditPostAsync(int postNumber, string title, string? description, CancellationToken token = default);
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3156577/197368184-d931c012-1a9b-4f09-8cb8-97e0b22be7fd.png)

The description parameter is optional in the sense if not provided it will be assumed to be empty - not that it won't update. The code before assumed it operated in the previous manner, causing the descriptions to be removed when the title was updated.