### PR TITLE
Daemon/features/RegisterNewBounty: require 'approved' tag

### DIFF
--- a/src/MoneroBot.Daemon/Features/RegisterNewBounty.cs
+++ b/src/MoneroBot.Daemon/Features/RegisterNewBounty.cs
@@ -55,6 +55,12 @@ public class RegisterNewBountyHandler : IRegisterNewBountyHandler
             return null;
         }
 
+        if (!post.Tags.Contains("approved"))
+        {
+            this.logger.LogInformation("Post #{PostNumber} doesn't have the 'approved' tag, skipping registration", command.PostNumber);
+            return null;
+        }
+
         await using var transaction = await context.Database.BeginTransactionAsync(token);
         try
         {


### PR DESCRIPTION
this is more an issue for feedback on the best way to do this as i am yet to test this.

the Models/Post contains the Tags list already, thank you for making this less confusing.

Making this optional? i have no idea, this is my hack :(